### PR TITLE
Split looper events

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,7 @@
 				"noUnreachableSuper": "error",
 				"noUnsafeFinally": "error",
 				"noUnsafeOptionalChaining": "error",
+				"noUnusedPrivateClassMembers": "error",
 				"noUnusedLabels": "error",
 				"noUnusedVariables": "error",
 				"useArrayLiterals": "off",

--- a/src/game/procs/EnemySpawner.ts
+++ b/src/game/procs/EnemySpawner.ts
@@ -24,6 +24,10 @@ interface EnemySpawnerConfig {
 }
 
 export class EnemySpawner {
+	player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody; // the player
+	enemyGroup: Phaser.Physics.Arcade.Group; // group with all enemies
+	colliderLayers: Phaser.Tilemaps.TilemapLayer | null; // layer with all tiles that collide
+
 	constructor(level: Game, config?: EnemySpawnerConfig) {
 		this.player = level.player;
 		this.enemyGroup = level.enemyGroup;
@@ -71,8 +75,4 @@ export class EnemySpawner {
 			},
 		});
 	}
-
-	player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody; // the player
-	enemyGroup: Phaser.Physics.Arcade.Group; // group with all enemies
-	colliderLayers: Phaser.Tilemaps.TilemapLayer | null; // layer with all tiles that collide
 }

--- a/src/game/procs/EnemySpawner.ts
+++ b/src/game/procs/EnemySpawner.ts
@@ -1,0 +1,78 @@
+import { SpritesRat } from "../../types/assets";
+import { GAME_OPTIONS } from "../GameOptions";
+import { Game } from "../scenes/Game";
+
+interface EnemySpawnerConfig {
+	outerRectangle: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	innerRectangle: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	enemyWaves: {
+		rate: number;
+		delay: number;
+		count: number;
+		enemy: string; // TODO: replace with enemy class
+	}[];
+}
+
+export class EnemySpawner {
+	constructor(level: Game, config?: EnemySpawnerConfig) {
+		this.player = level.player;
+		this.enemyGroup = level.enemyGroup;
+		this.colliderLayers = level.colliderLayers;
+
+		const enemyWaves = config?.enemyWaves || [
+			{
+				enemy: SpritesRat.getName(),
+				rate: GAME_OPTIONS.enemyRate,
+				delay: 1000,
+				count: 1,
+			},
+		];
+
+		// set outer rectangle and inner rectangle; enemy spawn area is between these rectangles
+		const outerRectangle: Phaser.Geom.Rectangle = new Phaser.Geom.Rectangle(
+			this.player.x - (config?.outerRectangle?.x || 100),
+			this.player.y - (config?.outerRectangle?.y || 100),
+			GAME_OPTIONS.gameSize.width + (config?.outerRectangle?.width || 200),
+			GAME_OPTIONS.gameSize.height + (config?.outerRectangle?.height || 200),
+		);
+		const innerRectangle: Phaser.Geom.Rectangle = new Phaser.Geom.Rectangle(
+			this.player.x - (config?.innerRectangle?.x || 50),
+			this.player.y - (config?.innerRectangle?.y || 50),
+			GAME_OPTIONS.gameSize.width + (config?.innerRectangle?.width || 100),
+			GAME_OPTIONS.gameSize.height + (config?.innerRectangle?.height || 100),
+		);
+
+		const wave = enemyWaves[0]; // TODO: Loop over all waves
+		// timer event to add enemies
+		level.time.addEvent({
+			startAt: wave.delay,
+			delay: GAME_OPTIONS.enemyRate,
+			loop: true,
+			callback: () => {
+				for (let index = 0; index < wave.count; index++) {
+					const spawnPoint: Phaser.Geom.Point =
+						Phaser.Geom.Rectangle.RandomOutside(outerRectangle, innerRectangle);
+					const enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody =
+						level.physics.add.sprite(spawnPoint.x, spawnPoint.y, wave.enemy);
+					enemy.body.setSize(16, 16);
+					enemy.body.setOffset(8, 16);
+					this.enemyGroup.add(enemy);
+				}
+			},
+		});
+	}
+
+	player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody; // the player
+	enemyGroup: Phaser.Physics.Arcade.Group; // group with all enemies
+	colliderLayers: Phaser.Tilemaps.TilemapLayer | null; // layer with all tiles that collide
+}

--- a/src/game/procs/WeaponLooper.ts
+++ b/src/game/procs/WeaponLooper.ts
@@ -1,0 +1,55 @@
+import { SpritesWeapons } from "../../types/assets";
+import { GAME_OPTIONS } from "../GameOptions";
+import { Game } from "../scenes/Game";
+
+export class WeaponLooper {
+	constructor(level: Game, bulletsGroup: Phaser.Physics.Arcade.Group) {
+		level.time.addEvent({
+			delay: GAME_OPTIONS.bulletRate, // TODO: replace with player.attackSpeed,
+			loop: true,
+			callback: () => {
+				// TODO: itterate over player.weapons and do new Weapon() for each
+				const closestEnemy: any = level.physics.closest(
+					level.player,
+					level.enemyGroup.getMatching("visible", true),
+				);
+				if (closestEnemy != null) {
+					const bullet: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody =
+						level.physics.add.sprite(
+							level.player.x,
+							level.player.y,
+							SpritesWeapons.getName(),
+						);
+					bulletsGroup.add(bullet);
+					bullet.play("knife");
+
+					bullet.body.setAllowRotation(true);
+					bullet.rotation = Phaser.Math.Angle.Between(
+						level.player.x,
+						level.player.y,
+						closestEnemy.x,
+						closestEnemy.y,
+					);
+					bullet.body.setSize(2, 2);
+					level.physics.moveToObject(
+						bullet,
+						closestEnemy,
+						GAME_OPTIONS.bulletSpeed,
+					);
+				}
+			},
+		});
+
+		// bullet Vs enemy collision
+		level.physics.add.collider(
+			bulletsGroup,
+			level.enemyGroup,
+			(bullet: any, enemy: any) => {
+				bulletsGroup.killAndHide(bullet);
+				bullet.body.checkCollision.none = true;
+				level.enemyGroup.killAndHide(enemy);
+				enemy.body.checkCollision.none = true;
+			},
+		);
+	}
+}

--- a/src/game/scenes/Game.ts
+++ b/src/game/scenes/Game.ts
@@ -6,6 +6,7 @@ import {
 	TilemapsTileset,
 } from "../../types/assets";
 import { GAME_OPTIONS } from "../GameOptions";
+import { EnemySpawner } from "../procs/EnemySpawner";
 
 // PlayGame class extends Phaser.Scene class
 export class Game extends Phaser.Scene {
@@ -66,38 +67,7 @@ export class Game extends Phaser.Scene {
 			right: Phaser.Input.Keyboard.KeyCodes.D,
 		});
 
-		// set outer rectangle and inner rectangle; enemy spawn area is between these rectangles
-		const outerRectangle: Phaser.Geom.Rectangle = new Phaser.Geom.Rectangle(
-			this.player.x - 100,
-			this.player.y - 100,
-			GAME_OPTIONS.gameSize.width + 200,
-			GAME_OPTIONS.gameSize.height + 200,
-		);
-		const innerRectangle: Phaser.Geom.Rectangle = new Phaser.Geom.Rectangle(
-			this.player.x - 50,
-			this.player.y - 50,
-			GAME_OPTIONS.gameSize.width + 100,
-			GAME_OPTIONS.gameSize.height + 100,
-		);
-
-		// timer event to add enemies
-		this.time.addEvent({
-			delay: GAME_OPTIONS.enemyRate,
-			loop: true,
-			callback: () => {
-				const spawnPoint: Phaser.Geom.Point =
-					Phaser.Geom.Rectangle.RandomOutside(outerRectangle, innerRectangle);
-				const enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody =
-					this.physics.add.sprite(
-						spawnPoint.x,
-						spawnPoint.y,
-						SpritesRat.getName(),
-					);
-				enemy.body.setSize(16, 16);
-				enemy.body.setOffset(8, 16);
-				this.enemyGroup.add(enemy);
-			},
-		});
+		new EnemySpawner(this);
 
 		// timer event to fire bullets
 		this.time.addEvent({

--- a/src/game/scenes/Game.ts
+++ b/src/game/scenes/Game.ts
@@ -7,6 +7,7 @@ import {
 } from "../../types/assets";
 import { GAME_OPTIONS } from "../GameOptions";
 import { EnemySpawner } from "../procs/EnemySpawner";
+import { WeaponLooper } from "../procs/WeaponLooper";
 
 // PlayGame class extends Phaser.Scene class
 export class Game extends Phaser.Scene {
@@ -68,55 +69,7 @@ export class Game extends Phaser.Scene {
 		});
 
 		new EnemySpawner(this);
-
-		// timer event to fire bullets
-		this.time.addEvent({
-			delay: GAME_OPTIONS.bulletRate,
-			loop: true,
-			callback: () => {
-				const closestEnemy: any = this.physics.closest(
-					this.player,
-					this.enemyGroup.getMatching("visible", true),
-				);
-				if (closestEnemy != null) {
-					const bullet: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody =
-						this.physics.add.sprite(
-							this.player.x,
-							this.player.y,
-							SpritesWeapons.getName(),
-						);
-					bulletGroup.add(bullet);
-					bullet.play("knife");
-
-					bullet.body.setAllowRotation(true);
-					bullet.rotation = Phaser.Math.Angle.Between(
-						this.player.x,
-						this.player.y,
-						closestEnemy.x,
-						closestEnemy.y,
-					);
-					bullet.body.setSize(2, 2);
-					this.physics.moveToObject(
-						bullet,
-						closestEnemy,
-						GAME_OPTIONS.bulletSpeed,
-					);
-				}
-			},
-		});
-
-		// bullet Vs enemy collision
-		this.physics.add.collider(
-			bulletGroup,
-			this.enemyGroup,
-			(bullet: any, enemy: any) => {
-				bulletGroup.killAndHide(bullet);
-				bullet.body.checkCollision.none = true;
-				this.enemyGroup.killAndHide(enemy);
-				enemy.body.checkCollision.none = true;
-			},
-		);
-
+		new WeaponLooper(this, bulletGroup);
 		// player Vs enemy collision
 		this.physics.add.collider(this.player, this.enemyGroup, () => {
 			this.scene.restart();


### PR DESCRIPTION
# Summary :nerd_face: 
This PR splits the WeaponsLooper & EnemySpawner into different classes

## Warnings :warning: 
- Once we have the other base classes, we should reference them in these loopers
- For the Weapons Looper, we will want to itterate over the player's acquired weapons and add a new sprite to the bullet group when we have more weapons